### PR TITLE
Fix Docker image building process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data/uploads/**

--- a/build/flask/Dockerfile
+++ b/build/flask/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine:3.10
+ARG EXIFTOOL_VERSION=11.93
 
 #
 # ZSteg
@@ -24,16 +25,16 @@ RUN apk add steghide --update-cache --repository http://dl-cdn.alpinelinux.org/a
 # ExifTool
 #
 
-RUN apk add --no-cache perl make
+RUN apk add --no-cache perl make openssl wget
 RUN cd /tmp \
-    && wget http://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-11.53.tar.gz \
-    && tar -zxvf Image-ExifTool-11.53.tar.gz \
-    && cd Image-ExifTool-11.53 \
+    && wget https://exiftool.org/Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz \
+    && tar -zxvf Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz \
+    && cd Image-ExifTool-${EXIFTOOL_VERSION} \
     && perl Makefile.PL \
     && make test \
     && make install \
     && cd .. \
-    && rm -rf Image-ExifTool-11.53
+    && rm -rf Image-ExifTool-${EXIFTOOL_VERSION}
 
 
 #

--- a/build/flask/Dockerfile
+++ b/build/flask/Dockerfile
@@ -67,6 +67,4 @@ WORKDIR /opt/aperisolve
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
-
 CMD [ "python", "./app.py" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ version: '3'
 services:
     aperisolve:
         build: ./build/flask
+        image: zeecka/aperisolve:latest
         container_name: aperisolve
         hostname: aperisolve
         environment:


### PR DESCRIPTION
In order to allow users to run the Aperisolve project under docker-composes based on a pre-built image, you need to add an "image" tag in the aperisolve service.

I also removed unused file copy in the Dockerfile and updated the exiftool installation part.