### PR TITLE
added automatic workflow for push and build to GHCR

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,79 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+
+  docker-releases-web:
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get release version
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+    
+    - name: downcase username
+      run: echo "lower_actor=${GITHUB_ACTOR,,}" >> $GITHUB_ENV
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v6.9.0
+      with:
+          context: ./web/
+          push: true
+          tags: |
+                 ghcr.io/${{ env.lower_actor }}/aperisolve-web:latest
+                 ghcr.io/${{ env.lower_actor }}/aperisolve-web:${{ env.RELEASE_VERSION }}
+  
+  docker-releases-backend:
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get release version
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+    
+    - name: downcase username
+      run: echo "lower_actor=${GITHUB_ACTOR,,}" >> $GITHUB_ENV
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v6.9.0
+      with:
+          context: ./backend/
+          push: true
+          tags: |
+                 ghcr.io/${{ env.lower_actor }}/aperisolve-backend:latest
+                 ghcr.io/${{ env.lower_actor }}/aperisolve-backend:${{ env.RELEASE_VERSION }}
+

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ Both of the two part has its own docker container.
 
 # VI . Run with Docker-Compose
 
-Simply run the following command:
+You can pull all the images from the GitHub Container Registry. A simple docker compose file is included in the repos. Just use:  
 ```bash
-docker-compose build
-docker-compose up
+docker compose -f docker-compose.yml up
 ```
 
 Then check your browser at [http://localhost:5000/](http://localhost:5000).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 services:
   web:
-    build: web
-    restart: always
+    image: ghcr.io/zeecka/aperisolve-web:v2.2
     container_name: aperisolve_web
     volumes:
-      - ./web:/app
+      - aperisolve-data:/app/static/uploads
     ports:
       - "5000:5000"
     env_file:
@@ -15,12 +14,10 @@ services:
       - frontend
       - backend
   backend:
-    build: backend
-    restart: always
+    image: ghcr.io/zeecka/aperisolve-backend:v2.2
     container_name: aperisolve_back
     volumes:
-      - ./backend:/app
-      - ./web/static/uploads:/app/uploads
+      - aperisolve-data:/app/uploads
     env_file:
       - .env
     depends_on:
@@ -35,12 +32,17 @@ services:
     env_file:
       - .env
     volumes:
-      - ./mongo/data:/data/db
+      - aperisolve-db:/data/db
       - ./mongo/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
     networks:
       - backend
+
 networks:
   frontend:
     driver: bridge
   backend:
     driver: bridge
+volumes:
+  aperisolve-data: # All uploads will be stored in this volume
+  aperisolve-db: # All mongo db related data will be stored in this volume
+  


### PR DESCRIPTION
Give the ability to publish images on GitHub Container Registry automatically when a new version is released (through tags).  This allow to let people do whatever they want with docker compose instead of already providing a Docker compose file. That said I let it as an example.

This will ease deployment because people will be no longer required to:
- git clone / git pull
- docker build over and over again
... when a new update comes in or as a first install. 

Instead, when a new version is released, GitHub action will automatically build the images and push them into the registry which they can be pulled from just like with Docker Hub. Then the rest of the update process can be automated through Watchtower from the docker users perspectives. 

Github Action will build 2 images according to the different Dockerfiles you wrote and push them under the names: aperisolve-web:version and aperisolve-backend:tag. You can [find an example](https://github.com/RMI78/AperiSolve/actions/runs/11645152057/job/32427867229) on my forked repo where I re-created the hole thing with your last tag and let github action build the images for me then put them in the releases section.

I also changed some shared directories into Docker volumes to make it look cleaner and updated the README accordingly. 

Let me know what you think, if you want to change some stuff or not etc.

Ce repo mérite carrément plus d'étoiles, c'est du super travail, bravo et merci beaucoup pour tout les flags que j'ai pu récupérer rapidement grace a cet outil. 