### PR TITLE
switch to latest tags in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/zeecka/aperisolve-web:v2.2
+    image: ghcr.io/zeecka/aperisolve-web:latest
     container_name: aperisolve_web
     volumes:
       - aperisolve-data:/app/static/uploads
@@ -14,7 +14,7 @@ services:
       - frontend
       - backend
   backend:
-    image: ghcr.io/zeecka/aperisolve-backend:v2.2
+    image: ghcr.io/zeecka/aperisolve-backend:latest
     container_name: aperisolve_back
     volumes:
       - aperisolve-data:/app/uploads


### PR DESCRIPTION
Quick fix on docker compose file prior to #62 as 2.2 tags are not working. Tested with 3.0 tag and seem to work (can't see why). Look like I made a breaking changes last time. Anyways, switching them to latest so we won't have to update it everytime.   