### PR TITLE
Fix double file browser opening issue

### DIFF
--- a/aperisolve/static/js/aperisolve.js
+++ b/aperisolve/static/js/aperisolve.js
@@ -367,8 +367,13 @@ function showFilename(filename) {
 
 if (browseBtn) {
   // Clicking the button triggers file input
-  browseBtn.addEventListener("click", () => fileInput.click());
-  dropZone.addEventListener("click", () => fileInput.click());
+  browseBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    fileInput.click();
+  });
+  dropZone.addEventListener("click", () => {
+    fileInput.click();
+  });
   dropZone.addEventListener("dragover", (e) => {
     e.preventDefault();
     dropZone.style.boxShadow = "0 0 20px #9fef00";


### PR DESCRIPTION
When I click on the "Choose an image" button both dropZone and browserBtn are triggered. This opens the file browser twice. This fixes it.

Interestingly this does not happen on firefox on my Debian 3.12. This only happens on my Brave on Windows 10.