### PR TITLE
fix: use relative imports in models.py for Docker compatibility

### DIFF
--- a/aperisolve/models.py
+++ b/aperisolve/models.py
@@ -22,8 +22,8 @@ from sqlalchemy import (
     String,
 )
 
-from aperisolve.config import MAX_PENDING_TIME, MAX_STORE_TIME, RESULT_FOLDER
-from aperisolve.utils.utils import get_resolutions, get_valid_depth_color_pairs
+from .config import MAX_PENDING_TIME, MAX_STORE_TIME, RESULT_FOLDER
+from .utils.utils import get_resolutions, get_valid_depth_color_pairs
 
 db: SQLAlchemy = SQLAlchemy()
 


### PR DESCRIPTION
## Summary
- Changed absolute imports to relative imports in `aperisolve/models.py`
- Fixes module import errors when running in Docker with the Postgres container
- The absolute imports caused circular import issues in the containerized environment

## Test plan
- [ ] Build the Docker image with `docker-compose build`
- [ ] Start the containers with `docker-compose up`
- [ ] Verify the Postgres container starts without module import errors
- [ ] Test that AperiSolve functions correctly with the database

Fixes #168