### PR TITLE
fix(deploy): set PROJECT_VERSION from release tag so UI shows correct version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
 
             cat .env.example | grep -v '^PROJECT_VERSION=' > .env
             cat <<EOF >> .env
+            PROJECT_VERSION=${{ github.ref_name }}
             WEB_APP_PORT=${{ vars.WEB_APP_PORT }}
             MAX_CONTENT_LENGTH=${{ vars.MAX_CONTENT_LENGTH }}
             MAX_PENDING_TIME=${{ vars.MAX_PENDING_TIME }}


### PR DESCRIPTION
**Summary**
- Ensure the production `.env` includes `PROJECT_VERSION` (from the Git tag) so the app displays the real release version instead of `v.development`.

closes #188 

**What I changed**
- **File:** release.yml
- **Change:** Append `PROJECT_VERSION=${{ github.ref_name }}` into the generated `.env` during tagged deploys (so the deployment writes the release tag into the runtime environment).

**Root cause**
- Deploy script rebuilt `.env` from .env.example while filtering out the `PROJECT_VERSION` line, causing config.py to fall back to the default `"development"`. That made the UI render `v.development` instead of the actual release tag.

**How to verify**
- Push or re-run a tag-based release (e.g., tag `3.1.3`). After deploy:
  - Visit the site and confirm the footer/header shows the tag (e.g., `v3.1.3`).
  - Or SSH to the server and check `/root/AperiSolve/.env` contains `PROJECT_VERSION=<tag>`.

**Risk & notes**
- Low risk: this only modifies the deploy script for tagged releases.
- No app code changes required; `config.py` already reads `PROJECT_VERSION` from env.
- Optional follow-up: add a guard to fail deploy if `PROJECT_VERSION` is empty