### PR TITLE
[Enhancement] Sentry: Add Image Attachments for Debugging Analysis Errors and Error Reports

### DIFF
--- a/aperisolve/workers.py
+++ b/aperisolve/workers.py
@@ -30,7 +30,7 @@ from .models import Image, Submission, db
 from .utils.sentry import initialize_sentry
 
 
-def analyze_image(submission_hash: str) -> None: # noqa: C901, PLR0915
+def analyze_image(submission_hash: str) -> None:  # noqa: C901, PLR0915
     """Analyze an image submission by running multiple analysis tools concurrently."""
     initialize_sentry()
     app = create_app()

--- a/aperisolve/workers.py
+++ b/aperisolve/workers.py
@@ -1,9 +1,9 @@
 """Asynchronous worker for analyzing image submissions."""
 
+import mimetypes  # Added to dynamically detect the image MIME type
 import threading
 from collections.abc import Callable
 from pathlib import Path
-import mimetypes  # Added to dynamically detect the image MIME type
 
 import sentry_sdk
 from sqlalchemy.exc import SQLAlchemyError
@@ -69,11 +69,11 @@ def analyze_image(submission_hash: str) -> None:
                                 # Get the right MIME type (e.g., image/jpeg or image/png)
                                 mime_type, _ = mimetypes.guess_type(img_path)
                                 content_type = mime_type or "application/octet-stream"
-                                
+
                                 scope.add_attachment(
                                     bytes=img_path.read_bytes(),
                                     filename=submission.filename or img_path.name,
-                                    content_type=content_type
+                                    content_type=content_type,
                                 )
                             except Exception:
                                 pass  # Prevent file read issues from hiding the original error
@@ -129,11 +129,11 @@ def analyze_image(submission_hash: str) -> None:
                     try:
                         mime_type, _ = mimetypes.guess_type(img_path)
                         content_type = mime_type or "application/octet-stream"
-                        
+
                         scope.add_attachment(
                             bytes=img_path.read_bytes(),
                             filename=submission.filename or img_path.name,
-                            content_type=content_type
+                            content_type=content_type,
                         )
                     except Exception:
                         pass

--- a/aperisolve/workers.py
+++ b/aperisolve/workers.py
@@ -30,7 +30,7 @@ from .models import Image, Submission, db
 from .utils.sentry import initialize_sentry
 
 
-def analyze_image(submission_hash: str) -> None:
+def analyze_image(submission_hash: str) -> None: # noqa: C901, PLR0915
     """Analyze an image submission by running multiple analysis tools concurrently."""
     initialize_sentry()
     app = create_app()
@@ -75,7 +75,7 @@ def analyze_image(submission_hash: str) -> None:
                                     filename=submission.filename or img_path.name,
                                     content_type=content_type,
                                 )
-                            except Exception:
+                            except OSError:
                                 pass  # Prevent file read issues from hiding the original error
 
                         scope.set_tag("analyzer", analyzer_name)
@@ -135,7 +135,7 @@ def analyze_image(submission_hash: str) -> None:
                             filename=submission.filename or img_path.name,
                             content_type=content_type,
                         )
-                    except Exception:
+                    except OSError:
                         pass
                 sentry_sdk.capture_exception(exc)
             submission.status = "error"

--- a/aperisolve/workers.py
+++ b/aperisolve/workers.py
@@ -61,8 +61,6 @@ def analyze_image(submission_hash: str) -> None:
                     analyzer_func.__class__.__name__,
                 ).replace("analyze_", "")
                 try:
-                    if analyzer_name == "binwalk":
-                        raise ValueError("Simulated Worker Crash for Sentry!")
                     analyzer_func(*args)
                 except (RuntimeError, ValueError, OSError, TypeError) as exc:
                     with sentry_sdk.push_scope() as scope:

--- a/aperisolve/workers.py
+++ b/aperisolve/workers.py
@@ -3,6 +3,7 @@
 import threading
 from collections.abc import Callable
 from pathlib import Path
+import mimetypes  # Added to dynamically detect the image MIME type
 
 import sentry_sdk
 from sqlalchemy.exc import SQLAlchemyError
@@ -43,8 +44,10 @@ def analyze_image(submission_hash: str) -> None:
         submission.status = "running"
         db.session.commit()
 
+        # Define img_path earlier so it is available to the entire function scope
+        img_path = Path(image.file)
+
         try:
-            img_path = Path(image.file)
             result_path = RESULT_FOLDER / str(image.hash) / str(submission.hash)
             result_path.mkdir(parents=True, exist_ok=True)
 
@@ -58,9 +61,25 @@ def analyze_image(submission_hash: str) -> None:
                     analyzer_func.__class__.__name__,
                 ).replace("analyze_", "")
                 try:
+                    if analyzer_name == "binwalk":
+                        raise ValueError("Simulated Worker Crash for Sentry!")
                     analyzer_func(*args)
                 except (RuntimeError, ValueError, OSError, TypeError) as exc:
                     with sentry_sdk.push_scope() as scope:
+                        if img_path.exists():
+                            try:
+                                # Get the right MIME type (e.g., image/jpeg or image/png)
+                                mime_type, _ = mimetypes.guess_type(img_path)
+                                content_type = mime_type or "application/octet-stream"
+                                
+                                scope.add_attachment(
+                                    bytes=img_path.read_bytes(),
+                                    filename=submission.filename or img_path.name,
+                                    content_type=content_type
+                                )
+                            except Exception:
+                                pass  # Prevent file read issues from hiding the original error
+
                         scope.set_tag("analyzer", analyzer_name)
                         scope.set_tag("submission_hash", submission_hash)
                         scope.set_context(
@@ -107,7 +126,20 @@ def analyze_image(submission_hash: str) -> None:
 
             submission.status = "completed"
         except (RuntimeError, ValueError, OSError, TypeError, SQLAlchemyError) as exc:
-            sentry_sdk.capture_exception(exc)
+            with sentry_sdk.push_scope() as scope:
+                if img_path.exists():
+                    try:
+                        mime_type, _ = mimetypes.guess_type(img_path)
+                        content_type = mime_type or "application/octet-stream"
+                        
+                        scope.add_attachment(
+                            bytes=img_path.read_bytes(),
+                            filename=submission.filename or img_path.name,
+                            content_type=content_type
+                        )
+                    except Exception:
+                        pass
+                sentry_sdk.capture_exception(exc)
             submission.status = "error"
         finally:
             db.session.commit()


### PR DESCRIPTION
## Summary

This PR implements image attachments for errors reported to Sentry during image analysis.

Previously, when an analyzer failed, Sentry events contained the exception, stack trace, and associated metadata. While this provided useful debugging information, it was often difficult to understand whether the failure was caused by a specific property of the submitted image without having access to the original file.

With this change, the original submitted image is attached to Sentry events whenever an analyzer exception or a top-level analysis exception occurs. This allows maintainers to inspect the exact file that triggered the error directly from the Sentry dashboard.

## Implementation Details

### Analyzer-Level Exceptions

Inside `workers.py`, each analyzer is executed through the `run_analyzer()` wrapper function. When an analyzer raises one of the handled exceptions:

```python
RuntimeError
ValueError
OSError
TypeError
```
</code></pre><p>the worker now:</p><ol><li><p>Creates a dedicated Sentry scope.</p></li><li><p>Reads the original submitted image from disk.</p></li><li><p>Detects the image MIME type using <code inline="">mimetypes.guess_type()</code>.</p></li><li><p>Attaches the image to the Sentry event using <code inline="">scope.add_attachment(...)</code>.</p></li><li><p>Adds analyzer-specific metadata and tags.</p></li><li><p>Captures the exception in Sentry.</p></li></ol><p>Additional context included with the event:</p><ul><li><p>Analyzer name</p></li><li><p>Submission hash</p></li><li><p>Original filename</p></li><li><p>Image path</p></li><li><p>Result path</p></li><li><p>Deep analysis status</p></li></ul><p>This makes it easier to identify which analyzer failed and inspect the exact image that caused the issue.</p><h3>Top-Level Analysis Exceptions</h3><p>The same attachment logic has also been added to the outer exception handler that wraps the entire analysis workflow.</p><p>If an unexpected exception occurs outside of an individual analyzer (for example, during setup, result directory creation, database operations, etc.), the submitted image is still attached to the resulting Sentry event.</p><p>This ensures image context is available regardless of where the failure originates.</p><h3>MIME Type Detection</h3><p>Instead of hardcoding image formats, the implementation uses:</p><pre><code class="language-python">mimetypes.guess_type(img_path)
</code></pre><p>Examples:</p>
File | MIME Type
-- | --
image.jpg | image/jpeg
image.jpeg | image/jpeg
image.png | image/png
image.gif | image/gif
image.webp | image/webp

<p>If MIME type detection fails, the fallback value is:</p><pre><code class="language-python">application/octet-stream
</code></pre><h2>Testing</h2><h3>Test Image</h3><p>Testing was performed using the following sample image:</p>
<img width="300" height="168" alt="aperisolve issue" src="https://github.com/user-attachments/assets/4c189bbe-169a-4090-97e5-b8d3c741d187" />
<p>(A regular PNG image uploaded through the normal submission workflow.)</p><h3>Triggering a Test Error</h3><p>To verify the implementation, an intentional exception was introduced inside <code inline="">workers.py</code>.</p><p>For example, inside the <code inline="">run_analyzer()</code> function:</p><pre><code class="language-python">def run_analyzer(analyzer_func, *args):
    raise RuntimeError("Sentry attachment test")
</code></pre><p>Alternatively, a temporary exception can be added immediately before an analyzer execution:</p><pre><code class="language-python">raise RuntimeError("Sentry attachment test")
analyzer_func(*args)
</code></pre><p>After submitting an image and allowing the worker to process it:</p><ol><li><p>The exception was raised intentionally.</p></li><li><p>The event appeared in Sentry.</p></li><li><p>The uploaded image was attached to the event.</p></li><li><p>Analyzer metadata and submission information were visible in the event context.</p></li></ol><h3>Verification</h3><ul><li><p>Exception is successfully reported to Sentry.</p></li><li><p>Submitted image appears under the event attachments section.</p></li><li><p>Correct filename is displayed.</p></li><li><p>Correct image MIME type is detected.</p></li><li><p>Existing exception reporting behavior remains unchanged.</p></li><li><p>Attachment failures do not prevent exception reporting.</p></li></ul><h3>Evidence</h3><p>A screenshot of the Sentry event has been attached to this PR showing: 
<img width="1600" height="1056" alt="image" src="https://github.com/user-attachments/assets/d06cb221-e124-4ba7-84b0-34b855e4b461" />
<img width="1576" height="740" alt="image" src="https://github.com/user-attachments/assets/1e2145f4-878a-46da-86de-f06ac332be95" />
</p><ul><li><p>The generated exception.</p></li><li><p>Event metadata.</p></li><li><p>Attached source image visible within the Sentry dashboard.</p></li></ul><h2>Benefits</h2><ul><li><p>Faster debugging of image-specific failures.</p></li><li><p>Easier reproduction of edge-case issues.</p></li><li><p>Better visibility into malformed or unusual submissions.</p></li><li><p>Improved context for analyzer failures without requiring access to the original upload location.</p></li></ul><h2>Related Issue</h2><p>Closes #193 and Closes #192</p>