### PR TITLE
test: cover color_remapping analyzer and utils helpers (#138)

### DIFF
--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -10,11 +10,13 @@ import numpy as np
 import pytest
 from PIL import Image
 
+from aperisolve.analyzers.color_remapping import RANDOM_REMAPPING_COUNT, ColorRemappingAnalyzer
 from aperisolve.analyzers.decomposer import DecomposerAnalyzer
 from aperisolve.analyzers.file import FileAnalyzer
 from aperisolve.analyzers.outguess import OutguessAnalyzer
 from aperisolve.analyzers.pdfid import PdfidAnalyzer
 from aperisolve.analyzers.pdfinfo import PdfinfoAnalyzer
+from aperisolve.analyzers.pil_utils import PALETTE_NOTE
 from aperisolve.analyzers.spectrogram import SpectrogramAnalyzer
 from aperisolve.analyzers.strings import StringsAnalyzer
 from aperisolve.filetype import detect_file_type
@@ -218,3 +220,79 @@ def test_detect_file_type_missing_path_never_raises() -> None:
     ft = detect_file_type(Path("/nonexistent/aperisolve/does-not-exist.bin"))
     assert ft.kind == "other"
     assert ft.tags == frozenset()
+
+
+def _synthetic_image(path: Path, mode: str, size: tuple[int, int] = (16, 16)) -> None:
+    """Write a small deterministic image in the requested PIL ``mode``.
+
+    A fixed ramp (rather than random noise) keeps the input reproducible; the
+    remapping the analyzer applies on top is what varies.
+    """
+    w, h = size
+    base = (np.arange(w * h, dtype=np.uint8) % 251).reshape(h, w)
+    if mode == "L":
+        Image.fromarray(base, "L").save(path)
+        return
+    green = (base + 80).astype(np.uint8)
+    blue = (base + 160).astype(np.uint8)
+    if mode == "RGB":
+        Image.fromarray(np.dstack([base, green, blue]), "RGB").save(path)
+    elif mode == "RGBA":
+        alpha = np.full((h, w), 200, dtype=np.uint8)
+        Image.fromarray(np.dstack([base, green, blue, alpha]), "RGBA").save(path)
+    elif mode == "P":
+        Image.fromarray(np.dstack([base, green, blue]), "RGB").convert("P").save(path)
+    else:
+        msg = f"unsupported mode {mode}"
+        raise ValueError(msg)
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_out_mode"),
+    [("L", "RGB"), ("RGB", "RGB"), ("RGBA", "RGBA"), ("P", "RGB")],
+)
+def test_color_remapping_supports_common_modes(
+    tmp_path: Path,
+    mode: str,
+    expected_out_mode: str,
+) -> None:
+    """Grayscale, RGB, RGBA and palette inputs each yield the full set of PNGs.
+
+    RGBA keeps its alpha channel (output stays RGBA); every other mode is
+    emitted as RGB, exercising both branches of ``_create_remapped_image``.
+    """
+    src = tmp_path / f"{mode.lower()}.png"
+    _synthetic_image(src, mode)
+    ColorRemappingAnalyzer.execute(src, tmp_path)
+
+    entry = _read_results(tmp_path)["color_remapping"]
+    assert entry["status"] == "ok", entry
+    assert len(entry["images"]["Color Remapping"]) == RANDOM_REMAPPING_COUNT
+
+    for i in range(RANDOM_REMAPPING_COUNT):
+        png = tmp_path / f"color_remapping_{i:02d}.png"
+        assert png.exists(), png
+        with Image.open(png) as img:
+            img.load()
+            assert img.mode == expected_out_mode, (png.name, img.mode)
+
+
+def test_color_remapping_notes_palette_conversion(tmp_path: Path) -> None:
+    """A palette (mode 'P') input is converted to RGB and carries the note."""
+    src = tmp_path / "palette.png"
+    _synthetic_image(src, "P")
+    ColorRemappingAnalyzer.execute(src, tmp_path)
+
+    entry = _read_results(tmp_path)["color_remapping"]
+    assert entry["status"] == "ok", entry
+    assert entry["note"] == PALETTE_NOTE
+
+
+def test_color_remapping_errors_on_undecodable_input(tmp_path: Path) -> None:
+    """A file Pillow cannot decode is recorded as an error, never an exception."""
+    junk = tmp_path / "not-an-image.png"
+    junk.write_bytes(os.urandom(2048))
+    ColorRemappingAnalyzer.execute(junk, tmp_path)
+
+    entry = _read_results(tmp_path)["color_remapping"]
+    assert entry["status"] == "error", entry

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,83 @@
+"""Tests for the pure-Python helpers in ``aperisolve.utils.utils``."""
+
+from flask import Flask
+
+from aperisolve.utils.utils import (
+    MAX_RESOLUTION_SIZE,
+    get_client_ip,
+    get_resolutions,
+    get_valid_depth_color_pairs,
+    int2hex,
+    str2hex,
+)
+
+# PNG-valid (bit depth, color type) combinations, mirroring the tool's own map.
+VALID_DEPTHS = {1, 2, 4, 8, 16}
+VALID_COLORS = {0, 2, 3, 4, 6}
+
+
+def test_str2hex_uppercases_and_encodes() -> None:
+    """Bytes render as an uppercase, unprefixed hex string."""
+    assert str2hex(b"\x00\xff\x10") == "00FF10"
+    assert str2hex(b"") == ""
+
+
+def test_int2hex_prefixes_and_uppercases() -> None:
+    """Integers render as ``0x``-prefixed uppercase hex."""
+    assert int2hex(0) == "0x0"
+    assert int2hex(255) == "0xFF"
+    assert int2hex(4096) == "0x1000"
+
+
+def test_get_resolutions_are_sorted_unique_and_symmetric() -> None:
+    """Resolutions come back sorted, deduplicated, in bounds, and orientation-symmetric."""
+    res = get_resolutions()
+    assert res  # non-empty
+    assert res == sorted(res)
+    assert len(res) == len(set(res))
+
+    res_set = set(res)
+    for w, h in res:
+        assert w >= 1
+        assert 1 <= h <= MAX_RESOLUTION_SIZE
+        # Every resolution has its portrait/landscape mirror.
+        assert (h, w) in res_set
+
+
+def test_get_valid_depth_color_pairs_are_all_valid_and_unique() -> None:
+    """Every yielded pair is a real PNG depth/color combo, with no duplicates."""
+    pairs = list(get_valid_depth_color_pairs())
+    assert pairs
+    assert len(pairs) == len(set(pairs))
+
+    for depth, color in pairs:
+        assert depth in VALID_DEPTHS
+        assert color in VALID_COLORS
+
+    # Spot-check representative combinations across color types.
+    assert (8, 2) in pairs  # 8-bit truecolor
+    assert (1, 0) in pairs  # 1-bit grayscale
+    assert (16, 6) in pairs  # 16-bit truecolor + alpha
+    assert (16, 3) not in pairs  # palette tops out at 8-bit
+
+
+def test_get_client_ip_takes_rightmost_forwarded_hop() -> None:
+    """The closest-proxy (rightmost) X-Forwarded-For hop is the trusted one."""
+    app = Flask(__name__)
+    headers = {"X-Forwarded-For": "1.1.1.1, 2.2.2.2, 3.3.3.3"}
+    with app.test_request_context(headers=headers):
+        assert get_client_ip() == "3.3.3.3"
+
+
+def test_get_client_ip_falls_back_to_remote_addr() -> None:
+    """Without the forwarded header, the socket peer address is used."""
+    app = Flask(__name__)
+    with app.test_request_context(environ_base={"REMOTE_ADDR": "9.9.9.9"}):
+        assert get_client_ip() == "9.9.9.9"
+
+
+def test_get_client_ip_empty_when_nothing_available() -> None:
+    """A missing peer address degrades to an empty string, never ``None``."""
+    app = Flask(__name__)
+    with app.test_request_context(environ_base={"REMOTE_ADDR": ""}):
+        assert get_client_ip() == ""


### PR DESCRIPTION
## What

Adds regression tests for the two largest **pure-Python** coverage gaps under #138 — no new external-binary dependencies, so these run everywhere (locally and in CI).

| Module | Before | After |
| --- | --- | --- |
| `analyzers/color_remapping.py` | 30% | **96%** |
| `utils/utils.py` | 47% | **100%** |
| **Total** | ~72% | **~75%** |

### `color_remapping` analyzer (`tests/test_analyzers.py`)
Drives the analyzer through its real `execute()` entry point (writes/reads `results.json`), covering:
- grayscale (`L`), `RGB`, `RGBA`, and palette (`P`) inputs — asserting RGBA keeps its alpha while other modes emit RGB, so both branches of `_create_remapped_image` are exercised;
- the palette-conversion `note` (`PALETTE_NOTE`);
- the undecodable-input path, verifying a corrupt file is recorded as `status: error` rather than raising.

Inputs are small deterministic synthetic images built in-test (same style as the existing synthetic-WAV spectrogram tests).

### `utils/utils.py` (`tests/test_utils.py`)
`str2hex`, `int2hex`, `get_resolutions` (sorted / unique / bounded / orientation-symmetric invariants), `get_valid_depth_color_pairs` (all pairs are valid PNG depth/color combos), and `get_client_ip` (confirms the trusted **rightmost** `X-Forwarded-For` hop, `REMOTE_ADDR` fallback, and empty-string degradation).

## Verification
`ruff check` · `ruff format --check` · `ty check aperisolve` · full `pytest` all green — **114 passed, 22 skipped**, total coverage **74.89%** (CI floor of 55% untouched).

## Notes
The broad test suite this issue asked for already exists (`tests/` + `tests/fixtures/` + `examples/`); this PR closes the notable remaining gaps in pure-Python, always-runnable code. Binary-gated analyzers (steghide/pcrt/outguess/…) stay low only because their tools are absent in CI and their tests `skip` — that's expected and unchanged here.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)