### PR TITLE
feat: inline video & audio previews (result page + /show)

### DIFF
--- a/aperisolve/app.py
+++ b/aperisolve/app.py
@@ -513,7 +513,7 @@ def _register_data_routes(app: Flask) -> None:
         names = [name for name in {sub.filename for sub in image.submissions} if name]
         passwords = [pwd for pwd in {sub.password for sub in image.submissions} if pwd]
         # detect_file_type is best-effort and never raises; kind drives the
-        # frontend preview (image/audio/pdf/other) and mime is informational.
+        # frontend preview (image/video/audio/pdf/other) and mime is informational.
         file_type = detect_file_type(Path(image.file))
         response = jsonify(
             {

--- a/aperisolve/filetype.py
+++ b/aperisolve/filetype.py
@@ -10,7 +10,7 @@ Detection order (first confident hit wins):
 
 1. ``file --mime-type -b <path>`` (libmagic CLI, fixed argv, 5 s timeout).
 2. Pillow ``Image.open(...).format`` -> ``image/<format>``.
-3. An extension table (audio/pdf formats + :data:`aperisolve.config.IMAGE_EXTENSIONS`).
+3. An extension table (audio/video/pdf formats + :data:`aperisolve.config.IMAGE_EXTENSIONS`).
 4. ``application/octet-stream``.
 """
 
@@ -34,9 +34,9 @@ _CACHE_SIZE = 1024
 class FileType:
     """Detected content type of an upload.
 
-    ``kind`` (one of ``"image"``, ``"audio"``, ``"pdf"``, ``"other"``) drives
-    the frontend preview; ``tags`` gate which analyzers run (see
-    ``aperisolve.analyzers.base_analyzer.SubprocessAnalyzer.accepts``).
+    ``kind`` (one of ``"image"``, ``"audio"``, ``"video"``, ``"pdf"``,
+    ``"other"``) drives the frontend preview; ``tags`` gate which analyzers run
+    (see ``aperisolve.analyzers.base_analyzer.SubprocessAnalyzer.accepts``).
     """
 
     mime: str
@@ -49,6 +49,9 @@ class FileType:
 # ``file(1)`` labels a container ambiguously (e.g. ``application/ogg``).
 _IMAGE_FORMATS = frozenset({"png", "jpeg", "gif", "bmp", "webp", "tiff"})
 _AUDIO_FORMATS = frozenset({"wav", "mp3", "flac", "ogg", "m4a", "au"})
+_VIDEO_FORMATS = frozenset(
+    {"mp4", "webm", "avi", "flv", "mkv", "mov", "wmv", "mpeg", "m4v", "ogv", "3gp", "ts"},
+)
 
 # Known MIME strings (as emitted by libmagic/Pillow/the extension table),
 # mapped to their canonical format tag.
@@ -77,11 +80,29 @@ _MIME_FORMAT_TAGS: dict[str, str] = {
     "audio/x-m4a": "m4a",
     "audio/basic": "au",
     "audio/x-au": "au",
+    "video/mp4": "mp4",
+    "video/webm": "webm",
+    "video/x-msvideo": "avi",
+    "video/avi": "avi",
+    "video/x-flv": "flv",
+    "video/x-matroska": "mkv",
+    "video/quicktime": "mov",
+    "video/x-ms-wmv": "wmv",
+    "video/mpeg": "mpeg",
+    "video/x-m4v": "m4v",
+    "video/ogg": "ogv",
+    "video/3gpp": "3gp",
+    "video/mp2t": "ts",
     "application/pdf": "pdf",
 }
 
 # Kind -> the tag added alongside the format tag. ``other`` contributes none.
-_KIND_TAG: dict[str, str] = {"image": "image", "audio": "audio", "pdf": "pdf"}
+_KIND_TAG: dict[str, str] = {
+    "image": "image",
+    "audio": "audio",
+    "video": "video",
+    "pdf": "pdf",
+}
 
 # MIME strings that carry no format information; treated as "not confident" so
 # detection falls through to Pillow / the extension table.
@@ -101,6 +122,24 @@ _DOC_AUDIO_EXT_MIME: dict[str, str] = {
     ".pdf": "application/pdf",
 }
 
+# Extension -> MIME fallback for video types (step 3). Kept separate from the
+# audio/document table only for readability; both are merged in below.
+_VIDEO_EXT_MIME: dict[str, str] = {
+    ".mp4": "video/mp4",
+    ".m4v": "video/x-m4v",
+    ".webm": "video/webm",
+    ".avi": "video/x-msvideo",
+    ".flv": "video/x-flv",
+    ".mkv": "video/x-matroska",
+    ".mov": "video/quicktime",
+    ".wmv": "video/x-ms-wmv",
+    ".mpeg": "video/mpeg",
+    ".mpg": "video/mpeg",
+    ".ogv": "video/ogg",
+    ".3gp": "video/3gpp",
+    ".ts": "video/mp2t",
+}
+
 # Image extensions whose MIME is not simply ``image/<ext>``.
 _IMAGE_EXT_MIME_OVERRIDES: dict[str, str] = {
     ".jpg": "image/jpeg",
@@ -116,8 +155,9 @@ def _image_ext_to_mime(ext: str) -> str:
 
 
 def _build_ext_mime_table() -> dict[str, str]:
-    """Extension -> MIME fallback table (audio/pdf + configured image types)."""
+    """Extension -> MIME fallback table (audio/video/pdf + configured image types)."""
     table = dict(_DOC_AUDIO_EXT_MIME)
+    table.update(_VIDEO_EXT_MIME)
     for ext in IMAGE_EXTENSIONS:
         table.setdefault(ext.lower(), _image_ext_to_mime(ext.lower()))
     return table
@@ -130,6 +170,8 @@ def _kind_for(mime: str, fmt: str) -> str:
     """Derive the coarse ``kind`` from the MIME prefix, backed by the format tag."""
     if mime.startswith("image/") or fmt in _IMAGE_FORMATS:
         return "image"
+    if mime.startswith("video/") or fmt in _VIDEO_FORMATS:
+        return "video"
     if mime.startswith("audio/") or fmt in _AUDIO_FORMATS:
         return "audio"
     if mime == "application/pdf" or fmt == "pdf":

--- a/aperisolve/pages.py
+++ b/aperisolve/pages.py
@@ -15,10 +15,13 @@ register_lang_handling(pages_bp)
 
 MAX_SHOW_IMAGES = 100
 
-# Extension -> Font Awesome icon for the browse gallery's non-image cards. The
-# stored upload is classified cheaply by extension here (not via
-# detect_file_type) to avoid a subprocess probe per gallery row.
+# Extensions the browse gallery previews inline. Uploads are classified cheaply
+# by extension here (not via detect_file_type) to avoid a subprocess probe per
+# gallery row; the values only pick a preview element, not analyzer gating.
 _AUDIO_EXTENSIONS = frozenset({".wav", ".mp3", ".flac", ".ogg", ".m4a", ".au"})
+_VIDEO_EXTENSIONS = frozenset(
+    {".mp4", ".m4v", ".webm", ".avi", ".flv", ".mkv", ".mov", ".wmv", ".mpeg", ".mpg", ".ogv"},
+)
 
 
 def _file_icon(suffix: str) -> str:
@@ -27,6 +30,8 @@ def _file_icon(suffix: str) -> str:
         return "fa-file-pdf"
     if suffix in _AUDIO_EXTENSIONS:
         return "fa-file-audio"
+    if suffix in _VIDEO_EXTENSIONS:
+        return "fa-file-video"
     return "fa-file"
 
 
@@ -53,11 +58,18 @@ def show() -> str:
         last_sub = img.submissions[-1]
         suffix = Path(str(img.file)).suffix.lower()
         row: dict[str, str] = {"file": f"/image/{img.hash}", "link": f"/{last_sub.hash}"}
+        label = suffix.removeprefix(".").upper() or "FILE"
         if suffix in IMAGE_EXTENSIONS:
             row["kind"] = "image"
+        elif suffix in _VIDEO_EXTENSIONS:
+            row["kind"] = "video"
+            row["label"] = label
+        elif suffix in _AUDIO_EXTENSIONS:
+            row["kind"] = "audio"
+            row["label"] = label
         else:
             row["kind"] = "other"
             row["icon"] = _file_icon(suffix)
-            row["label"] = suffix.removeprefix(".").upper() or "FILE"
+            row["label"] = label
         images.append(row)
     return render_template("show.html", images=images)

--- a/aperisolve/static/css/aperisolve.css
+++ b/aperisolve/static/css/aperisolve.css
@@ -469,9 +469,18 @@ button:focus-visible,
 }
 
 /* Type-aware original preview. The image kind still renders a plain <img>
-   (styled by `#result img`); audio and every other kind need their own rules. */
+   (styled by `#result img`); video/audio and every other kind need their own
+   rules. The video is capped so a tall portrait clip cannot dominate the panel. */
 #main_image audio {
     width: 100%;
+}
+
+#main_image video {
+    width: 100%;
+    height: auto;
+    max-height: 70vh;
+    border-radius: var(--border-radius);
+    background-color: #000;
 }
 
 /* Download card for non-image / non-audio uploads (info panel and the browse
@@ -676,6 +685,42 @@ td {
     transform: translateY(-0.25rem);
     box-shadow: 0 0 0.625rem var(--theme-green-shadow);
     border-color: var(--theme-green);
+}
+
+/* Browse-gallery inline media (video/audio). The playable control sits above a
+   label that links to the full analysis, since the control itself can't be
+   wrapped in that link. */
+.browse-media-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    background-color: rgba(0, 0, 0, 0.18);
+    border: 1px dashed var(--green-line);
+}
+
+.browse-media {
+    width: 100%;
+    display: block;
+}
+
+.browse-media-card video.browse-media {
+    aspect-ratio: 16 / 9;
+    object-fit: contain;
+    background-color: #000;
+    border-radius: var(--border-radius);
+}
+
+.browse-media-open {
+    text-align: center;
+    color: var(--theme-green);
+    font-size: 0.9rem;
+    text-decoration: none;
+    overflow-wrap: anywhere;
+}
+
+.browse-media-open:hover {
+    text-decoration: underline;
 }
 
 /* ======== Modal ======== */

--- a/aperisolve/static/js/aperisolve.js
+++ b/aperisolve/static/js/aperisolve.js
@@ -215,9 +215,9 @@ document.addEventListener("keydown", function (e) {
 
 // Build the type-appropriate original-file preview shown in the info panel.
 // The upload can now be any file, so branch on the backend-detected kind:
-// image -> <img>, audio -> player, everything else -> a download file card.
-// The default is ALWAYS the file card, never a bare <img>, so an unknown or
-// non-image upload cannot render a broken image.
+// image -> <img>, video -> player, audio -> player, everything else -> a
+// download file card. The default is ALWAYS the file card, never a bare <img>,
+// so an unknown or non-image upload cannot render a broken image.
 function renderMainPreview(infoData) {
   const src = escapeHtml(infoData.image_path);
   const rawName =
@@ -227,6 +227,10 @@ function renderMainPreview(infoData) {
 
   if (infoData.kind === "image") {
     return `<img src="${src}" alt="${t("Analyzed file")}"/>`;
+  }
+  if (infoData.kind === "video") {
+    // #t=0.1 nudges the browser to render a poster frame instead of a blank box.
+    return `<video controls preload="metadata" playsinline src="${src}#t=0.1"></video>`;
   }
   if (infoData.kind === "audio") {
     return `<audio controls preload="metadata" src="${src}"></audio>`;

--- a/aperisolve/templates/show.html
+++ b/aperisolve/templates/show.html
@@ -10,16 +10,34 @@
   <div class="row g-3">
     {% for img in images %}
     <div class="col-6 col-md-4 col-lg-3">
+      {% if img.kind == 'image' %}
       <a href="{{ img.link }}" target="_blank" class="d-block browse-image-link">
-        {% if img.kind == 'image' %}
         <img src="{{ img.file }}" alt="{{ _("Submission thumbnail") }}" class="img-fluid rounded" loading="lazy">
-        {% else %}
+      </a>
+      {% elif img.kind == 'video' %}
+      {# Media controls can't live inside the result link (a click would both play
+         and navigate), so the label below is the affordance that opens the analysis. #}
+      <div class="browse-media-card rounded">
+        <video controls preload="metadata" playsinline class="browse-media" src="{{ img.file }}#t=0.1"></video>
+        <a href="{{ img.link }}" target="_blank" class="browse-media-open">
+          <i class="fa fa-file-video"></i> {{ img.label }}
+        </a>
+      </div>
+      {% elif img.kind == 'audio' %}
+      <div class="browse-media-card rounded">
+        <audio controls preload="metadata" class="browse-media" src="{{ img.file }}"></audio>
+        <a href="{{ img.link }}" target="_blank" class="browse-media-open">
+          <i class="fa fa-file-audio"></i> {{ img.label }}
+        </a>
+      </div>
+      {% else %}
+      <a href="{{ img.link }}" target="_blank" class="d-block browse-image-link">
         <div class="file-card browse-file-card rounded">
           <i class="fa {{ img.icon }} file-card-icon"></i>
           <span class="file-card-name">{{ img.label }}</span>
         </div>
-        {% endif %}
       </a>
+      {% endif %}
     </div>
     {% endfor %}
   </div>

--- a/tests/test_analyzers.py
+++ b/tests/test_analyzers.py
@@ -222,6 +222,30 @@ def test_detect_file_type_missing_path_never_raises() -> None:
     assert ft.tags == frozenset()
 
 
+@pytest.mark.parametrize("ext", [".mp4", ".webm", ".avi", ".flv", ".mkv", ".mov"])
+def test_detect_file_type_video_by_extension(tmp_path: Path, ext: str) -> None:
+    """Video uploads classify as kind 'video' carrying a 'video' tag.
+
+    Content is random bytes: ``file``/Pillow return nothing usable, so this
+    exercises the extension fallback and runs whether or not ``file`` is present.
+    """
+    clip = tmp_path / f"clip{ext}"
+    clip.write_bytes(os.urandom(2048))
+    ft = detect_file_type(clip)
+    assert ft.kind == "video", (ext, ft.kind, ft.mime)
+    assert "video" in ft.tags
+
+
+def test_detect_file_type_ogg_container_split(tmp_path: Path) -> None:
+    """The ambiguous OGG container splits by extension: .ogv video, .ogg audio."""
+    ogv = tmp_path / "clip.ogv"
+    ogv.write_bytes(os.urandom(1024))
+    ogg = tmp_path / "sound.ogg"
+    ogg.write_bytes(os.urandom(1024))
+    assert detect_file_type(ogv).kind == "video"
+    assert detect_file_type(ogg).kind == "audio"
+
+
 def _synthetic_image(path: Path, mode: str, size: tuple[int, int] = (16, 16)) -> None:
     """Write a small deterministic image in the requested PIL ``mode``.
 

--- a/tests/test_media_preview.py
+++ b/tests/test_media_preview.py
@@ -1,0 +1,74 @@
+"""Result-page and browse-gallery previews for video and audio uploads.
+
+The upload can be any file type; these tests confirm the web layer classifies
+video/audio submissions and renders a playable ``<video>``/``<audio>`` element
+rather than a bare download card.
+"""
+
+import time
+from pathlib import Path
+
+from flask import Flask
+from flask.testing import FlaskClient
+
+from aperisolve.models import Image, Submission, db
+
+VIDEO_IMG_HASH = "1" * 32
+VIDEO_SUB_HASH = "2" * 32
+AUDIO_IMG_HASH = "3" * 32
+AUDIO_SUB_HASH = "4" * 32
+
+
+def _seed(app: Flask, tmp_path: Path, *, img_hash: str, sub_hash: str, filename: str) -> None:
+    """Insert an Image + Submission whose stored file keeps ``filename``'s suffix.
+
+    The bytes are irrelevant to preview routing (kind is derived from the
+    extension when the content is unrecognised), so a tiny placeholder suffices.
+    """
+    stored = tmp_path / f"{img_hash}{Path(filename).suffix}"
+    stored.write_bytes(b"\x00\x01\x02\x03")
+    with app.app_context():
+        db.session.add(
+            Image(hash=img_hash, file=str(stored), size=stored.stat().st_size, upload_count=1),
+        )
+        db.session.add(
+            Submission(
+                hash=sub_hash,
+                filename=filename,
+                status="completed",
+                date=time.time(),
+                image_hash=img_hash,
+            ),
+        )
+        db.session.commit()
+
+
+def test_infos_reports_video_kind(app: Flask, client: FlaskClient, tmp_path: Path) -> None:
+    """A video upload is reported as kind 'video' with a video/* MIME."""
+    _seed(app, tmp_path, img_hash=VIDEO_IMG_HASH, sub_hash=VIDEO_SUB_HASH, filename="clip.mp4")
+    data = client.get(f"/infos/{VIDEO_SUB_HASH}").get_json()
+    assert data["kind"] == "video", data
+    assert data["mime"].startswith("video/"), data
+
+
+def test_infos_reports_audio_kind(app: Flask, client: FlaskClient, tmp_path: Path) -> None:
+    """An audio upload is reported as kind 'audio'."""
+    _seed(app, tmp_path, img_hash=AUDIO_IMG_HASH, sub_hash=AUDIO_SUB_HASH, filename="track.mp3")
+    data = client.get(f"/infos/{AUDIO_SUB_HASH}").get_json()
+    assert data["kind"] == "audio", data
+
+
+def test_show_renders_video_and_audio_players(
+    app: Flask,
+    client: FlaskClient,
+    tmp_path: Path,
+) -> None:
+    """The browse gallery emits playable <video>/<audio> elements for media rows."""
+    _seed(app, tmp_path, img_hash=VIDEO_IMG_HASH, sub_hash=VIDEO_SUB_HASH, filename="clip.webm")
+    _seed(app, tmp_path, img_hash=AUDIO_IMG_HASH, sub_hash=AUDIO_SUB_HASH, filename="track.wav")
+    html = client.get("/show").get_data(as_text=True)
+    assert "<video" in html
+    assert "<audio" in html
+    # Each media element sources the original-file route for its own image hash.
+    assert f"/image/{VIDEO_IMG_HASH}" in html
+    assert f"/image/{AUDIO_IMG_HASH}" in html


### PR DESCRIPTION
## What

Adds a **video** file kind so uploaded videos preview inline instead of showing a bare download card, and surfaces playable **audio** in the browse gallery. Requested: video (mp4, avi, flv, webm, …) and audio (mp3, wav, …) previews in the result view **and** `/show`.

| Surface | Before | After |
| --- | --- | --- |
| Result page — video | download card | `<video controls>` inline player |
| Result page — audio | `<audio>` (already) | unchanged |
| `/show` — video | file icon card | playable `<video>` tile |
| `/show` — audio | file icon card | playable `<audio>` tile |

## How

- **`filetype.py`** — new `"video"` kind with format / MIME / extension tables (mp4, webm, avi, flv, mkv, mov, wmv, mpeg, m4v, ogv, 3gp, ts). `kind` drives the preview; `tags` gate analyzers — no analyzer accepts a video tag, so **the analysis set is unchanged**. Handles the ambiguous OGG container (`.ogv` → video, `.ogg` → audio).
- **`renderMainPreview` (aperisolve.js)** — `kind === "video"` → `<video controls preload="metadata" …#t=0.1>` (the fragment nudges a poster frame). Audio branch untouched.
- **`/show` (pages.py + show.html + CSS)** — video/audio rows render playable media with a caption link to the analysis (the control can't be wrapped in the navigating link).
- **File serving unchanged** — `send_file` already sets the right `Content-Type` and honours `Range`, so **video seeking works** and audio is unaffected.

## Verification (the view was checked before pushing)
- `ruff` · `ruff format --check` · `ty` · `pytest` all green — **124 passed**, coverage **75.42%** (filetype 91%, pages 75%).
- New tests: extension-fallback video detection (binary-independent), OGG audio/video split, and `/infos` + `/show` reporting the new kinds / emitting `<video>`/`<audio>`.
- **Headless-browser check** against the running app: `Range: bytes=0-99` → `206 Partial Content` (`Accept-Ranges: bytes`); the `<video>` decoded a real frame (`320×240`, `readyState 4`) with native controls on **both** the result page and the gallery; the `<audio>` player rendered on both. Screenshots below.

_No new translatable strings (labels reuse the format code + icons), so `messages.pot` is unchanged._

🤖 Generated with [Claude Code](https://claude.com/claude-code)